### PR TITLE
Fix bug where new users are not redirected to /settings/get_started

### DIFF
--- a/frontend/app/auth/exchangeCode.ts
+++ b/frontend/app/auth/exchangeCode.ts
@@ -1,6 +1,6 @@
 'use client';
 
-const exchangeCode = async (code: string): Promise<void> => {
+const exchangeCode = async (code: string): Promise<{ isUserNew: boolean }> => {
   const res = await fetch(
     `${process.env.NEXT_PUBLIC_GOLANG_URL}/auth/exchange`,
     {
@@ -27,6 +27,8 @@ const exchangeCode = async (code: string): Promise<void> => {
   if (!cookieRes.ok) {
     throw new Error('Failed to Set Authentication Cookie.');
   }
+
+  return { isUserNew: data.is_user_new === true }; // If field is empty return false
 };
 
 export default exchangeCode;

--- a/frontend/app/auth/page.tsx
+++ b/frontend/app/auth/page.tsx
@@ -8,13 +8,10 @@ export default async function AuthPage({
 }) {
   const params = await searchParams;
   const code = Array.isArray(params.code) ? params.code[0] : params.code;
-  const isUserNew = Array.isArray(params.is_user_new)
-    ? params.is_user_new[0] === 'true'
-    : params.is_user_new === 'true' || false;
 
   if (!code) {
     return <Alert severity='error'>Missing Authorization Code.</Alert>;
   }
 
-  return <AuthCard code={code} isUserNew={isUserNew} />;
+  return <AuthCard code={code} />;
 }

--- a/frontend/components/auth/AuthCard.tsx
+++ b/frontend/components/auth/AuthCard.tsx
@@ -10,13 +10,7 @@ import { useRouter } from 'next/navigation';
 import exchangeCode from '@/app/auth/exchangeCode';
 import Alert from '@mui/material/Alert';
 
-export default function AuthCard({
-  code,
-  isUserNew,
-}: {
-  code: string;
-  isUserNew: boolean;
-}) {
+export default function AuthCard({ code }: { code: string }) {
   const router = useRouter();
   const [error, setError] = useState<string | null>(null);
 
@@ -24,7 +18,7 @@ export default function AuthCard({
     if (!code) return;
 
     exchangeCode(code)
-      .then(() => {
+      .then(({ isUserNew }: { isUserNew: boolean }) => {
         router.push(isUserNew ? '/settings/get_started' : 'home');
       })
       .catch((err: unknown) => {
@@ -35,7 +29,7 @@ export default function AuthCard({
           setError('Failed to Exchange Code.');
         }
       });
-  }, [code, isUserNew, router]);
+  }, [code, router]);
 
   if (error) {
     return <Alert severity='error'>{error}</Alert>;


### PR DESCRIPTION
## Screenshots: 

- When new user is created, page redirects to `/settings/get_started`.

<img width="1919" height="1140" alt="image" src="https://github.com/user-attachments/assets/18048e0d-ef0e-44ec-a238-44251dcd8291" />
